### PR TITLE
Пофиксил опасный вызов rm -rf

### DIFF
--- a/voice-domains-generator.sh
+++ b/voice-domains-generator.sh
@@ -11,7 +11,6 @@ kill -sighup $(pgrep dnsmasq) 2> /dev/null || echo "Куда же подевал
 check_domain() {
     domain=$1
     region=$2
-    directory="./regions/$region"
 
     mkdir -p "$directory"
 
@@ -27,8 +26,13 @@ check_domain() {
 
 for region in $regions; do
     echo "\nГенерируем и резолвим домены для региона: $region"
+    directory="./regions/$region"
 
-    rm -rf "$directory/*"
+    [ -z "$directory" ] && {
+        echo 'Чуть не сделали rm -rf /*'
+        exit 1
+    }
+    rm -rf "${directory:?}"/*
 
     start_time=$(date +%s)
     start_date=$(date +'%d.%m.%Y в %H:%M:%S')


### PR DESCRIPTION
При запуске voice-domains-generator.sh без заранее заданной $directory выполнится rm -rf "/*"
В связи с этим: 
1. Задаем значение для directory перед вызовом rm -rf
2. Если почему-то $directory так и осталась пустой, то скрипт выйдет с кодом 1