### PR TITLE
Use env for bash shebang

### DIFF
--- a/custom-solutions/MikL9/amnezia-warp-builder/warp_generator.sh
+++ b/custom-solutions/MikL9/amnezia-warp-builder/warp_generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 clear
 mkdir -p ~/.cloudshell && touch ~/.cloudshell/no-apt-get-warning # Для Google Cloud Shell, но лучше там не выполнять

--- a/ipset-adder.sh
+++ b/ipset-adder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/json-voice-ip-converter.sh
+++ b/json-voice-ip-converter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/main-domains-resolver.sh
+++ b/main-domains-resolver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/voice-domains-generator.sh
+++ b/voice-domains-generator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## Пожалуйста, убедитесь, что ваш PR соответствует следующим требованиям:

- [x] Изменения протестированы локально.

## Описание изменений

`#!/usr/bin/env` searches `$PATH` for `bash`, and `bash` is not always in `/bin`, particularly on non-Linux systems.
For example, on OpenBSD systems, it's in `/usr/local/bin`, since it is an optional package.
On ARM macOS, it's in `/opt/homebrew/bin/bash`

## Ссылки на связанные ресурсы или тикеты (если таковые есть)
https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash
https://ru.stackoverflow.com/questions/541589/%D0%92-%D1%87%D1%91%D0%BC-%D1%81%D0%BC%D1%8B%D1%81%D0%BB-%D0%B8-%D0%BF%D1%80%D0%B5%D0%B8%D0%BC%D1%83%D1%89%D0%B5%D1%81%D1%82%D0%B2%D0%B0-usr-bin-env
